### PR TITLE
MAKER-295 False negative after successful update

### DIFF
--- a/src/main/java/com/intel/galileo/flash/tool/GalileoFirmwareUpdater.java
+++ b/src/main/java/com/intel/galileo/flash/tool/GalileoFirmwareUpdater.java
@@ -407,6 +407,7 @@ public class GalileoFirmwareUpdater {
                 log.info("poll ...  " + ++i);
                 if (communicationService.openConnection(communicationConnection)) {
                     // we can talk to the board
+                    Thread.sleep(5000);	//sleep one last time to allow clloader a chance to start
                     GalileoVersion v = getCurrentBoardVersion();
                     boolean success = ((v != null) && 
                             (v.compareTo(update.getVersion()) == 0));


### PR DESCRIPTION
Adds a delay after initial serial port connection to allow clloader a
chance to start before doing a board version query
