### PR TITLE
MAKER-307 Board version query fail due to garbage

### DIFF
--- a/src/main/java/com/intel/galileo/flash/tool/GalileoFirmwareUpdater.java
+++ b/src/main/java/com/intel/galileo/flash/tool/GalileoFirmwareUpdater.java
@@ -191,11 +191,14 @@ public class GalileoFirmwareUpdater {
             }
             
             try {
-                String rawVersion = communicationService.sendCommandWithTimeout(VERSION_COMMAND, 250);
-                int endIndex = rawVersion.indexOf(TRANSFER_COMPLETE);
-                if (endIndex > 0) {
-                    rawVersion = rawVersion.substring(0, endIndex).trim();
-                    currentBoardVersion = GalileoVersion.ofTargetString(rawVersion);
+            	for(int i =0 ;(currentBoardVersion==null && (i < 5));i++){
+	                String rawVersion = communicationService.sendCommandWithTimeout(VERSION_COMMAND, 250);
+	                int endIndex = rawVersion.indexOf(TRANSFER_COMPLETE);
+	                if (endIndex > 0) {
+	                    rawVersion = rawVersion.substring(0, endIndex).trim();
+	                    currentBoardVersion = GalileoVersion.ofTargetString(rawVersion);
+	                    break;
+	                }
                 }
             } catch (Exception ex) {
                 getLogger().log(Level.SEVERE, null, ex);


### PR DESCRIPTION
When doing a board version query, it sometimes outputs garbage including
the output string.
Changed to trying 4 more times when a query fails.
