### PR TITLE
Maker-352 Make service connection box invisible

### DIFF
--- a/src/main/java/com/intel/galileo/flash/tool/PreferencesPanel.java
+++ b/src/main/java/com/intel/galileo/flash/tool/PreferencesPanel.java
@@ -152,6 +152,8 @@ public class PreferencesPanel extends javax.swing.JPanel {
             }
             
         }
+        jLabel1.setVisible(false);
+        servicesComboBox.setVisible(false);
         updateCanvasBasedInURL(isThereAnyCap());
 
         updateFirmwareVersion();


### PR DESCRIPTION
Make service connection box invisible since there is only one choice for
now
