### PR TITLE
MAKER-360 Disable update button when clicked

### DIFF
--- a/src/main/java/com/intel/galileo/flash/tool/PreferencesPanel.java
+++ b/src/main/java/com/intel/galileo/flash/tool/PreferencesPanel.java
@@ -335,12 +335,17 @@ public class PreferencesPanel extends javax.swing.JPanel {
         msgJlabel = new javax.swing.JLabel();
         msgJlabel.setHorizontalAlignment(SwingConstants.CENTER);
         
+        uploadFirmwareButton.addActionListener(new java.awt.event.ActionListener() {
+        	public void actionPerformed(java.awt.event.ActionEvent evt) {
+        		uploadFirmwareButtonActionPerformed(evt);
+        	}
+        });
         uploadFirmwareButton.setAction(updateAction);
+        
         
         jLabel1.setHorizontalAlignment(javax.swing.SwingConstants.RIGHT);
         jLabel1.setText("Connection:");
         servicesComboBox.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "None Available" }));	
-
 
         jLabel2.setHorizontalAlignment(javax.swing.SwingConstants.RIGHT);
         jLabel2.setText("Port:");
@@ -540,6 +545,10 @@ public class PreferencesPanel extends javax.swing.JPanel {
 			e.printStackTrace();
 		}
     }//GEN-LAST:event_connectionComboBoxActionPerformed
+    
+    private void uploadFirmwareButtonActionPerformed(java.awt.event.ActionEvent evt) {
+    	uploadFirmwareButton.setEnabled(false);
+    }
     
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JTextField boardVersion;


### PR DESCRIPTION
Disable the  update button once it is clicked to prevent the update
operation from trying to run twice.
