### PR TITLE
MAKER-373 Update firmware does not work via File Menu

### DIFF
--- a/src/main/java/com/intel/galileo/flash/tool/FirmwareUpdateTool.java
+++ b/src/main/java/com/intel/galileo/flash/tool/FirmwareUpdateTool.java
@@ -135,7 +135,10 @@ public class FirmwareUpdateTool extends JFrame {
     
     JMenu createFileMenu() {
         JMenu m = new JMenu("File");
-        m.add(new FirmwareUpdateAction(flasher,status));
+        FirmwareUpdateAction action;
+        action = new FirmwareUpdateAction(flasher,status);
+        action.setPreferencesPanel(preferences);
+        m.add(action);
         m.add(new AbstractAction("Quit") {
             @Override
             public void actionPerformed(ActionEvent e) {


### PR DESCRIPTION
Fixes the issue of the update firmware via file menu not working that
was introduced by MAKER-368 fix
